### PR TITLE
Fix pubsub examples

### DIFF
--- a/examples/pubsub/subscriber-api.js
+++ b/examples/pubsub/subscriber-api.js
@@ -26,6 +26,7 @@ Studio(function billedApi(name) {
 
     console.log('Accessing number of shares for ' + name + ': 0');
 
+    // Erlich always has 0 shares.
     return {
         shares: 0
     };

--- a/examples/pubsub/subscriber-bill.js
+++ b/examples/pubsub/subscriber-bill.js
@@ -29,6 +29,8 @@ Studio(function billedApi(name) {
     // We charge $0.05 per API access
     bills[name] = (bills[name] || 0) + 0.05;
 
+    console.log('%s\'s bill is now %d', name, bills[name]);
+
     return {
         bill: bills[name]
     };

--- a/src/transport/localhost/transport.js
+++ b/src/transport/localhost/transport.js
@@ -80,7 +80,10 @@ LocalhostTransport.prototype.send = function (url, port, id, params, receiver) {
 
     self.api.send(JSON.stringify({i: _id, p: params, r: receiver, q: self._serverOpt.port, to: id, from: self._serverOpt.id}), port, url);
 
-    return promise.timeout(self._clientOpt.timeout || 60000);
+    return promise.timeout(self._clientOpt.timeout || 250).catch(self._Studio.promise.TimeoutError, function () {
+        // In case of timeout, we assume the service is unreachable
+        self.emit('end', { url: url, port: port, id: id});
+    });
 };
 
 module.exports = function (rpcPort, options) {

--- a/src/transport/localhost/transport.js
+++ b/src/transport/localhost/transport.js
@@ -40,14 +40,14 @@ function LocalhostTransport(port, serverOpt, clientOpt, Studio) {
 
                         refs[payload.r].apply(null, payload.p)
                             .then(function (res) {
-                                api.send(JSON.stringify({i: payload.i, m: res, s: 1}), payload.q, msg.address);
+                                api.send(JSON.stringify({i: payload.i, m: res, s: 1, to: payload.from, from: serverOpt.id}), payload.q, serverOpt.multicastAddress);
                             })
                             .catch(function (err) {
                                 err = serializeError(err);
 
-                                api.send(JSON.stringify({i: payload.i, m: err, s: 0}), payload.q, msg.address);
+                                api.send(JSON.stringify({i: payload.i, m: err, s: 0, to: payload.from, from: serverOpt.id}), payload.q, serverOpt.multicastAddress);
                             });
-                    } else if (payload && payload.i && self._promises[payload.i]) {
+                    } else if (payload && payload.i && self._promises[payload.i] && payload.to === serverOpt.id) {
                         func = payload.s ? self._promises[payload.i].resolve : self._promises[payload.i].reject;
                         delete self._promises[payload.i];
                         func(payload.m);
@@ -78,7 +78,7 @@ LocalhostTransport.prototype.send = function (url, port, id, params, receiver) {
         reject: _reject
     };
 
-    self.api.send(JSON.stringify({i: _id, p: params, r: receiver, q: self._serverOpt.port, to: id}), port, url);
+    self.api.send(JSON.stringify({i: _id, p: params, r: receiver, q: self._serverOpt.port, to: id, from: self._serverOpt.id}), port, url);
 
     return promise.timeout(self._clientOpt.timeout || 60000);
 };


### PR DESCRIPTION
If a message times out to a service on the localhost transport, the service will be removed from the service registry.  The default timeout is 250ms for a remote call.  It can be adjusted via setting if the workload takes longer.
